### PR TITLE
Cleanup the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,20 @@
 
 This library provides an API for serializing and de-serializing Elixir terms using the [MessagePack](http://msgpack.org/) format.
 
-[Documentation is available online][docs-msgpax].
+[Documentation is available online][docs].
+
+## Features
+
+* Packing and unpacking Elixir terms via [`Msgpax.pack/1`][docs-msgpax-pack-1] and [`Msgpax.unpack/1`][docs-msgpax-unpack-1] (and their `!` bang variants).
+* Unpacking of partial slices of MessagePack-encoded terms via [`Msgpax.unpack_slice/1`][docs-msgpax-unpack_slice-1].
+* Support for "Binary" and "Extension" MessagePack types via [`Msgpax.Bin`][docs-msgpax-bin] and [`Msgpax.Ext`][docs-msgpax-ext], respectively.
+* Protocol-based packing through the [`Msgpax.Packer`][docs-msgpax-packer] protocol, that can be derived for user-defined structs.
+
+A detailed table that shows the relationship between Elixir types and MessagePack types can be found in the [documentation for the `Msgpax` module][docs-msgpax].
 
 ## Installation
 
-Add Msgpax as a dependency in your `mix.exs` file:
+Add `:msgpax` as a dependency in your `mix.exs` file:
 
 ```elixir
 def deps do
@@ -18,77 +27,17 @@ end
 
 After you are done, run `mix deps.get` in your shell to fetch the dependencies.
 
-## Usage
-
-```elixir
-{:ok, iodata} = Msgpax.pack([300, "Spartans"])
-# => {:ok, [<<146>>, [<<205, 1, 44>>, [<<168>>, "Spartans"]]]}
-iodata = Msgpax.pack!([300, "Spartans"])
-# ...
-{:ok, term} = Msgpax.unpack(iodata)
-# => {:ok, [300, "Spartans"]}
-term = Msgpax.unpack!(iodata)
-# => [300, "Spartans"]
-```
-
-#### Partial deserialization
-
-```elixir
-{term1, rest} = Msgpax.unpack_slice!(buffer)
-# => {[1, 2, 3], <<4>>}
-{:ok, term2, rest} = Msgpax.unpack_slice(rest)
-# => {:ok, 4, ""}
-```
-
-#### Support for the "Binary" and "Extension" types
-
-The "Binary" and the "Extension" types are supported through the [`Msgpax.Bin`][docs-msgpax-bin] and [`Msgpax.Ext`][docs-msgpax-ext] structs, respectively.
-
-An example of usage for `Msgpax.Bin`:
-
-```elixir
-msgbin = Msgpax.Bin.new(<<3, 18, 122, 27, 115>>)
-# => #Msgpax.Bin<<<3, 18, 122, 27, 115>>>
-iodata = Msgpax.pack!(msgbin)
-# => [<<196, 5>>, <<3, 18, 122, 27, 115>>]
-# ...
-code = Msgpax.unpack!(iodata, %{binary: true})
-# => #Msgpax.Bin<<<3, 18, 122, 27, 115>>>
-```
-
-#### Deriving of the `Msgpax.Packer` protocol
-
-```elixir
-defmodule User do
-  @derive [Msgpax.Packer]
-  defstruct [:name]
-end
-
-Msgpax.pack!(%User{name: "Juri"})
-# => [<<129>>, [[[<<164>>, "name"], [<<164>>, "Juri"]]]]
-```
-
-In the example above, information about the `User` struct is lost when decoding back to Elixir terms:
-
-```elixir
-%User{name: "Juri"} |> Msgpax.pack!() |> Msgpax.unpack!()
-# => %{"name" => "Juri"}
-```
-
-You can overcome this by using something like [Maptu][github-maptu]:
-
-```elixir
-map = %User{name: "Juri"} |> Msgpax.pack!() |> Msgpax.unpack!()
-Maptu.struct!(User, map)
-# => %User{name: "Juri"}
-```
-
 ## License
 
 This software is licensed under [the ISC license](LICENSE).
 
 
-[docs-msgpax]: http://hexdocs.pm/msgpax
+[docs]: http://hexdocs.pm/msgpax
+[docs-msgpax]: https://hexdocs.pm/msgpax/Msgpax.html
+[docs-msgpax-pack-1]: http://hexdocs.pm/msgpax/Msgpax.html#pack/1
+[docs-msgpax-unpack-1]: http://hexdocs.pm/msgpax/Msgpax.html#unpack/1
+[docs-msgpax-unpack_slice-1]: http://hexdocs.pm/msgpax/Msgpax.html#unpack_slice/1
+[docs-msgpax-packer]: http://hexdocs.pm/msgpax/Msgpax.Packer.html
 [docs-msgpax-bin]: http://hexdocs.pm/msgpax/Msgpax.Bin.html
 [docs-msgpax-ext]: http://hexdocs.pm/msgpax/Msgpax.Ext.html
 [github-maptu]: https://github.com/whatyouhide/maptu


### PR DESCRIPTION
This will hopefully push people over to hexdocs.pm, where detailed documentation can be found.