### PR TITLE
Use the correct test matrix on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: elixir
 
-otp_release:
-  - 18.1
-  - 18.2
-
-elixir:
-  - 1.0.5
-  - 1.1.0
-  - 1.2.1
+matrix:
+  include:
+    - otp_release: 17.5
+      elixir: 1.0.5
+    - otp_release: 17.5
+      elixir: 1.1.1
+    - otp_release: 18.3
+      elixir: 1.1.1
+    - otp_release: 18.3
+      elixir: 1.2.6
+    - otp_release: 18.3
+      elixir: 1.3.1
+    - otp_release: 19.0
+      elixir: 1.3.1
 
 sudo: false
 


### PR DESCRIPTION
I think it's just faster and less error prone to manually specify all combinations of Erlang/Elixir versions.