### PR TITLE
Optimise unpacking by using single match context

### DIFF
--- a/lib/msgpax/unpacker.ex
+++ b/lib/msgpax/unpacker.ex
@@ -118,32 +118,32 @@ defmodule Msgpax.Unpacker do
   end
 
   def unpack_list(<<buffer::bytes>>, result, options, outer, length) do
-    unpack_list(buffer, result, options, outer, length, length)
+    unpack_list(buffer, result, options, outer, 0, length)
   end
 
-  def unpack_list(<<buffer::bytes>>, result, options, [], 0, count) do
+  def unpack_list(<<buffer::bytes>>, result, options, [], count, count) do
     {value, rest} = Enum.split(result, count)
     unpack(buffer, [:lists.reverse(value) | rest], options)
   end
 
-  def unpack_list(<<buffer::bytes>>, result, options, [{index, length} | outer], 0, count) do
+  def unpack_list(<<buffer::bytes>>, result, options, [{index, length} | outer], count, count) do
     {value, rest} = Enum.split(result, count)
-    unpack_list(buffer, [:lists.reverse(value) | rest], options, outer, index - 1, length)
+    unpack_list(buffer, [:lists.reverse(value) | rest], options, outer, index + 1, length)
   end
 
-  def unpack_list(<<buffer::bytes>>, result, options, [{index, length, :key} | outer], 0, count) do
+  def unpack_list(<<buffer::bytes>>, result, options, [{index, length, :key} | outer], count, count) do
     {value, rest} = Enum.split(result, count)
     unpack_map(buffer, [:lists.reverse(value) | rest], options, outer, index, length, :value)
   end
 
-  def unpack_list(<<buffer::bytes>>, result, options, [{index, length, :value} | outer], 0, count) do
+  def unpack_list(<<buffer::bytes>>, result, options, [{index, length, :value} | outer], count, count) do
     {value, [key | rest]} = Enum.split(result, count)
-    unpack_map(buffer, [{key, :lists.reverse(value)} | rest], options, outer, index - 1, length, :key)
+    unpack_map(buffer, [{key, :lists.reverse(value)} | rest], options, outer, index + 1, length, :key)
   end
 
   for {format, {:value, value}} <- formats do
     def unpack_list(<<unquote_splicing(format), rest::bytes>>, result, options, outer, index, length) do
-      unpack_list(rest, [unquote(value) | result], options, outer, index - 1, length)
+      unpack_list(rest, [unquote(value) | result], options, outer, index + 1, length)
     end
   end
 
@@ -159,27 +159,27 @@ defmodule Msgpax.Unpacker do
   end
 
   def unpack_map(<<buffer::bytes>>, result, options, outer, length) do
-    unpack_map(buffer, result, options, outer, length, length, :key)
+    unpack_map(buffer, result, options, outer, 0, length, :key)
   end
 
-  def unpack_map(<<buffer::bytes>>, result, options, [], 0, count, :key) do
+  def unpack_map(<<buffer::bytes>>, result, options, [], count, count, :key) do
     {value, rest} = Enum.split(result, count)
     unpack(buffer, [:maps.from_list(value) | rest], options)
   end
 
-  def unpack_map(<<buffer::bytes>>, result, options, [index, length, :key | outer], 0, count) do
+  def unpack_map(<<buffer::bytes>>, result, options, [index, length, :key | outer], count, count) do
     {value, rest} = Enum.split(result, count)
     unpack_map(buffer, [:maps.from_list(value) | rest], options, outer, index, length, :value)
   end
 
-  def unpack_map(<<buffer::bytes>>, result, options, [index, length, :value | outer], 0, count) do
+  def unpack_map(<<buffer::bytes>>, result, options, [index, length, :value | outer], count, count) do
     {value, rest} = Enum.split(result, count)
-    unpack_map(buffer, [:maps.from_list(value) | rest], options, outer, index - 1, length, :key)
+    unpack_map(buffer, [:maps.from_list(value) | rest], options, outer, index + 1, length, :key)
   end
 
-  def unpack_map(<<buffer::bytes>>, result, options, [{index, length} | outer], 0, count) do
+  def unpack_map(<<buffer::bytes>>, result, options, [{index, length} | outer], count, count) do
     {value, rest} = Enum.split(result, count)
-    unpack_list(buffer, [:maps.from_list(value) | rest], options, outer, index - 1, length)
+    unpack_list(buffer, [:maps.from_list(value) | rest], options, outer, index + 1, length)
   end
 
   for {format, {:value, value}} <- formats do
@@ -188,7 +188,7 @@ defmodule Msgpax.Unpacker do
     end
 
     def unpack_map(<<unquote_splicing(format), rest::bytes>>, [key | result], options, outer, index, length, :value) do
-      unpack_map(rest, [{key, unquote(value)} | result], options, outer, index - 1, length, :key)
+      unpack_map(rest, [{key, unquote(value)} | result], options, outer, index + 1, length, :key)
     end
   end
 

--- a/lib/msgpax/unpacker.ex
+++ b/lib/msgpax/unpacker.ex
@@ -133,7 +133,7 @@ defmodule Msgpax.Unpacker do
     options = Macro.var(:options, nil)
     outer = Macro.var(:outer, nil)
     defp unpack_collection(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, length, kind) when index < length do
-      outer = [kind, index, length | outer]
+      outer = [{kind, index, length} | outer]
       unquote(pipe(rest, pipe(result, pipe(options, pipe(outer, call, 0), 0), 0), 0))
     end
   end
@@ -167,7 +167,7 @@ defmodule Msgpax.Unpacker do
     Msgpax.Ext.new(type, data)
   end
 
-  defp unpack_continue(<<buffer::bits>>, result, options, [kind, index, length | outer]) do
+  defp unpack_continue(<<buffer::bits>>, result, options, [{kind, index, length} | outer]) do
     unpack_collection(buffer, result, options, outer, index + 1, length, kind)
   end
 

--- a/lib/msgpax/unpacker.ex
+++ b/lib/msgpax/unpacker.ex
@@ -56,7 +56,7 @@ defmodule Msgpax.Unpacker do
     [quote(do: [0b111::3, value::5])] => quote(do: value - 0b100000),
   }
   for {formats, value} <- primitives, format <- formats do
-    defp unpack(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, count) when index < count do
+    defp unpack(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, count) do
       result = [unquote(value) | result]
       case index + 1 do
         ^count ->
@@ -73,7 +73,7 @@ defmodule Msgpax.Unpacker do
     quote(do: [0xDD, length::32]),
   ]
   for format <- lists do
-    defp unpack(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, count) when index < count do
+    defp unpack(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, count) do
       case unquote(quote(do: length)) do
         0 ->
           result = [[] | result]
@@ -96,7 +96,7 @@ defmodule Msgpax.Unpacker do
     quote(do: [0xDF, length::32]),
   ]
   for format <- maps do
-    defp unpack(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, count) when index < count do
+    defp unpack(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, count) do
       case unquote(quote(do: length)) do
         0 ->
           result = [%{} | result]
@@ -119,7 +119,7 @@ defmodule Msgpax.Unpacker do
     quote(do: [0xC6, length::32, content::size(length)-bytes]),
   ]
   for format <- binaries do
-    defp unpack(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, count) when index < count do
+    defp unpack(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, count) do
       value = unpack_binary(unquote(quote(do: content)), options)
       result = [value | result]
       case index + 1 do
@@ -142,7 +142,7 @@ defmodule Msgpax.Unpacker do
     quote(do: [0xC9, length::32, type, content::size(length)-bytes]),
   ]
   for format <- extensions do
-    defp unpack(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, count) when index < count do
+    defp unpack(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, count) do
       value = unpack_ext(unquote(quote(do: type)), unquote(quote(do: content)), options)
       result = [value | result]
       case index + 1 do

--- a/lib/msgpax/unpacker.ex
+++ b/lib/msgpax/unpacker.ex
@@ -143,16 +143,12 @@ defmodule Msgpax.Unpacker do
   end
 
   defp unpack_map(<<buffer::bits>>, result, options, outer, length) do
-    unpack_map(buffer, result, options, outer, 0, length, :key)
+    unpack_map(buffer, result, options, outer, 0, length * 2, :key)
   end
 
   for {format, {:value, value}} <- formats do
-    defp unpack_map(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, length, :key) when index < length do
-      unpack_map(rest, [unquote(value) | result], options, outer, index, length, :value)
-    end
-
-    defp unpack_map(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, length, :value) when index < length do
-      unpack_map(rest, [unquote(value) | result], options, outer, index + 1, length, :key)
+    defp unpack_map(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, length, type) when index < length do
+      unpack_map(rest, [unquote(value) | result], options, outer, index + 1, length, type)
     end
   end
 
@@ -196,12 +192,8 @@ defmodule Msgpax.Unpacker do
     unpack_list(buffer, result, options, outer, index + 1, length)
   end
 
-  defp unpack_continue(<<buffer::bits>>, result, options, [{index, length, :key} | outer]) do
-    unpack_map(buffer, result, options, outer, index, length, :value)
-  end
-
-  defp unpack_continue(<<buffer::bits>>, result, options, [{index, length, :value} | outer]) do
-    unpack_map(buffer, result, options, outer, index + 1, length, :key)
+  defp unpack_continue(<<buffer::bits>>, result, options, [{index, length, type} | outer]) do
+    unpack_map(buffer, result, options, outer, index + 1, length, type)
   end
 
   defp unpack_continue(<<buffer::bits>>, result, options, []) do
@@ -221,6 +213,6 @@ defmodule Msgpax.Unpacker do
   end
 
   defp build_map([value, key | rest], pairs, count) do
-    build_map(rest, [{key, value} | pairs], count - 1)
+    build_map(rest, [{key, value} | pairs], count - 2)
   end
 end

--- a/lib/msgpax/unpacker.ex
+++ b/lib/msgpax/unpacker.ex
@@ -25,7 +25,7 @@ defmodule Msgpax.Unpacker do
   @moduledoc false
 
   def unpack(<<buffer::bits>>, options) do
-    unpack(buffer, [], options, [:root], 0, 1)
+    unpack(buffer, [], options, [], 0, 1)
   end
 
   primitives = %{
@@ -172,7 +172,7 @@ defmodule Msgpax.Unpacker do
     end
   end
 
-  defp unpack_continue(<<buffer::bits>>, _options, [:root], [value], 1) do
+  defp unpack_continue(<<buffer::bits>>, _options, [], [value], 1) do
     {value, buffer}
   end
 

--- a/lib/msgpax/unpacker.ex
+++ b/lib/msgpax/unpacker.ex
@@ -121,13 +121,8 @@ defmodule Msgpax.Unpacker do
     unpack_list(buffer, result, options, outer, 0, length)
   end
 
-  def unpack_list(<<buffer::bits>>, result, options, outer, count, count) do
-    {value, rest} = Enum.split(result, count)
-    unpack_continue(buffer, [:lists.reverse(value) | rest], options, outer)
-  end
-
   for {format, {:value, value}} <- formats do
-    def unpack_list(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, length) do
+    def unpack_list(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, length) when index < length do
       unpack_list(rest, [unquote(value) | result], options, outer, index + 1, length)
     end
   end
@@ -137,27 +132,27 @@ defmodule Msgpax.Unpacker do
     result = Macro.var(:result, nil)
     options = Macro.var(:options, nil)
     outer = Macro.var(:outer, nil)
-    def unpack_list(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, length) do
+    def unpack_list(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, length) when index < length do
       outer = [{index, length} | outer]
       unquote(pipe(rest, pipe(result, pipe(options, pipe(outer, call, 0), 0), 0), 0))
     end
+  end
+
+  def unpack_list(<<buffer::bits>>, result, options, outer, count, count) do
+    {value, rest} = Enum.split(result, count)
+    unpack_continue(buffer, [:lists.reverse(value) | rest], options, outer)
   end
 
   def unpack_map(<<buffer::bits>>, result, options, outer, length) do
     unpack_map(buffer, result, options, outer, 0, length, :key)
   end
 
-  def unpack_map(<<buffer::bits>>, result, options, outer, count, count, :key) do
-    {value, rest} = Enum.split(result, count)
-    unpack_continue(buffer, [:maps.from_list(value) | rest], options, outer)
-  end
-
   for {format, {:value, value}} <- formats do
-    def unpack_map(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, length, :key) do
+    def unpack_map(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, length, :key) when index < length do
       unpack_map(rest, [unquote(value) | result], options, outer, index, length, :value)
     end
 
-    def unpack_map(<<unquote_splicing(format), rest::bits>>, [key | result], options, outer, index, length, :value) do
+    def unpack_map(<<unquote_splicing(format), rest::bits>>, [key | result], options, outer, index, length, :value) when index < length do
       unpack_map(rest, [{key, unquote(value)} | result], options, outer, index + 1, length, :key)
     end
   end
@@ -167,10 +162,15 @@ defmodule Msgpax.Unpacker do
     result = Macro.var(:result, nil)
     options = Macro.var(:options, nil)
     outer = Macro.var(:outer, nil)
-    def unpack_map(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, length, type) do
+    def unpack_map(<<unquote_splicing(format), rest::bits>>, result, options, outer, index, length, type) when index < length do
       outer = [{index, length, type} | outer]
       unquote(pipe(rest, pipe(result, pipe(options, pipe(outer, call, 0), 0), 0), 0))
     end
+  end
+
+  def unpack_map(<<buffer::bits>>, result, options, outer, count, count, :key) do
+    {value, rest} = Enum.split(result, count)
+    unpack_continue(buffer, [:maps.from_list(value) | rest], options, outer)
   end
 
   defp unpack_ext(<<buffer::bits>>, result, options, outer, type, data) do


### PR DESCRIPTION
It gives from 20% speedup for highly nested complex data structures to 42% speedup for plain long maps or lists.