### PR TITLE
Implement Timestamp extension type

### DIFF
--- a/lib/msgpax.ex
+++ b/lib/msgpax.ex
@@ -8,22 +8,23 @@ defmodule Msgpax do
   The following table shows how Elixir types are serialized to MessagePack types
   and how MessagePack types are de-serialized back to Elixir types.
 
-  Elixir                         | MessagePack   | Elixir
-  ------------------------------ | ------------- | -------------
-  `nil`                          | nil           | `nil`
-  `true`                         | boolean       | `true`
-  `false`                        | boolean       | `false`
-  `-1`                           | integer       | `-1`
-  `1.25`                         | float         | `1.25`
-  `:ok`                          | string        | `"ok"`
-  `Atom`                         | string        | `"Elixir.Atom"`
-  `"str"`                        | string        | `"str"`
-  `"\xFF\xFF"`                   | string        | `"\xFF\xFF"`
-  `#Msgpax.Bin<"\xFF">`          | binary        | `"\xFF"`
-  `%{foo: "bar"}`                | map           | `%{"foo" => "bar"}`
-  `[foo: "bar"]`                 | map           | `%{"foo" => "bar"}`
-  `[1, true]`                    | array         | `[1, true]`
-  `#Msgpax.Ext<4, "02:12">`      | extension     | `#Msgpax.Ext<4, "02:12">`
+  Elixir                            | MessagePack   | Elixir
+  --------------------------------- | ------------- | -------------
+  `nil`                             | nil           | `nil`
+  `true`                            | boolean       | `true`
+  `false`                           | boolean       | `false`
+  `-1`                              | integer       | `-1`
+  `1.25`                            | float         | `1.25`
+  `:ok`                             | string        | `"ok"`
+  `Atom`                            | string        | `"Elixir.Atom"`
+  `"str"`                           | string        | `"str"`
+  `"\xFF\xFF"`                      | string        | `"\xFF\xFF"`
+  `#Msgpax.Bin<"\xFF">`             | binary        | `"\xFF"`
+  `%{foo: "bar"}`                   | map           | `%{"foo" => "bar"}`
+  `[foo: "bar"]`                    | map           | `%{"foo" => "bar"}`
+  `[1, true]`                       | array         | `[1, true]`
+  `#Msgpax.Ext<4, "02:12">`         | extension     | `#Msgpax.Ext<4, "02:12">`
+  `#DateTime<2017-12-06 00:00:00Z>` | extension     | `#DateTime<2017-12-06 00:00:00Z>`
 
   """
 

--- a/lib/msgpax/ext.ex
+++ b/lib/msgpax/ext.ex
@@ -78,7 +78,7 @@ defmodule Msgpax.Ext do
   @doc """
   Creates a new `Msgpax.Ext` struct.
 
-  `type` must be an integer in `0..127` and it will be used as the type of the
+  `type` must be an integer in `-128..127` and it will be used as the type of the
   extension (whose meaning depends on your application). `data` must be a binary
   containing the serialized extension (whose serialization depends on your
   application).

--- a/lib/msgpax/ext.ex
+++ b/lib/msgpax/ext.ex
@@ -66,8 +66,7 @@ defmodule Msgpax.Ext do
 
   """
 
-  @type type :: -128..127
-
+  @type type :: 0..127
   @type t :: %__MODULE__{
     type: type,
     data: binary,
@@ -78,7 +77,7 @@ defmodule Msgpax.Ext do
   @doc """
   Creates a new `Msgpax.Ext` struct.
 
-  `type` must be an integer in `-128..127` and it will be used as the type of the
+  `type` must be an integer in `0..127` and it will be used as the type of the
   extension (whose meaning depends on your application). `data` must be a binary
   containing the serialized extension (whose serialization depends on your
   application).
@@ -90,7 +89,7 @@ defmodule Msgpax.Ext do
 
   """
   def new(type, data)
-      when type in -128..127 and is_binary(data) do
+      when type in 0..127 and is_binary(data) do
     %__MODULE__{type: type, data: data}
   end
 

--- a/lib/msgpax/ext.ex
+++ b/lib/msgpax/ext.ex
@@ -66,7 +66,7 @@ defmodule Msgpax.Ext do
 
   """
 
-  @type type :: 0..127
+  @type type :: -128..127
 
   @type t :: %__MODULE__{
     type: type,
@@ -90,7 +90,7 @@ defmodule Msgpax.Ext do
 
   """
   def new(type, data)
-      when type in 0..127 and is_binary(data) do
+      when type in -128..127 and is_binary(data) do
     %__MODULE__{type: type, data: data}
   end
 

--- a/lib/msgpax/ext/rsvd_ext.ex
+++ b/lib/msgpax/ext/rsvd_ext.ex
@@ -90,8 +90,16 @@ defmodule Msgpax.Ext.RsvdUnpacker do
         total_nanos = seconds * 1000000000 + nanoseconds
         DateTime.from_unix(total_nanos, :nanosecond)
       12 ->
-        <<nanoseconds::32, seconds::64 >> = data
+        <<nanoseconds::32, seconds::64>> = data
         total_nanos = seconds * 1000000000 + nanoseconds
+        #Erlang only support datetime max to #<DateTime(9999-12-31T23:59:59Z Etc/UTC)>
+        #min to #<DateTime(0000-01-01T00:00:00Z Etc/UTC)> 
+        total_nanos = 
+        cond do
+          total_nanos < -62167219200000000000 -> -62167219200000000000
+          total_nanos > 253402300799999999999 -> 253402300799999999999
+          true -> total_nanos
+        end
         DateTime.from_unix(total_nanos, :nanosecond)
       _->
         :error

--- a/lib/msgpax/ext/rsvd_ext.ex
+++ b/lib/msgpax/ext/rsvd_ext.ex
@@ -105,4 +105,8 @@ defmodule Msgpax.Ext.RsvdUnpacker do
         :error
     end
   end
+  
+  def unpack(%Msgpax.Ext{type: type, data: _}) do
+    throw({:not_supported_reserved_ext, type})
+  end
 end

--- a/lib/msgpax/ext/rsvd_ext.ex
+++ b/lib/msgpax/ext/rsvd_ext.ex
@@ -81,20 +81,20 @@ defmodule Msgpax.Ext.RsvdUnpacker do
   def unpack(%Msgpax.Ext{type: -1, data: data}) do
     case byte_size(data) do
       4 ->
-        <<seconds::32>> = data
+        <<seconds::big-integer-size(32)>> = data
         DateTime.from_unix(seconds)
       8 ->
-        <<data64::64>> = data
+        <<data64::big-integer-size(64)>> = data
         nanoseconds = data64 >>> 34;
         seconds = data64 &&& 17179869183
         total_nanos = seconds * 1000000000 + nanoseconds
         DateTime.from_unix(total_nanos, :nanosecond)
       12 ->
-        <<nanoseconds::32, seconds::64>> = data
+        <<nanoseconds::big-integer-size(32), seconds::signed-big-integer-size(64)>> = data
         total_nanos = seconds * 1000000000 + nanoseconds
         #Erlang only support datetime max to #<DateTime(9999-12-31T23:59:59Z Etc/UTC)>
-        #min to #<DateTime(0000-01-01T00:00:00Z Etc/UTC)> 
-        total_nanos = 
+        #min to #<DateTime(0000-01-01T00:00:00Z Etc/UTC)>
+        total_nanos =
         cond do
           total_nanos < -62167219200000000000 -> -62167219200000000000
           total_nanos > 253402300799000000999 -> 253402300799000000999
@@ -105,7 +105,7 @@ defmodule Msgpax.Ext.RsvdUnpacker do
         :error
     end
   end
-  
+
   def unpack(%Msgpax.Ext{type: type, data: _}) do
     throw({:not_supported_reserved_ext, type})
   end

--- a/lib/msgpax/ext/rsvd_ext.ex
+++ b/lib/msgpax/ext/rsvd_ext.ex
@@ -97,7 +97,7 @@ defmodule Msgpax.Ext.RsvdUnpacker do
         total_nanos = 
         cond do
           total_nanos < -62167219200000000000 -> -62167219200000000000
-          total_nanos > 253402300799999999999 -> 253402300799999999999
+          total_nanos > 253402300799000000999 -> 253402300799000000999
           true -> total_nanos
         end
         DateTime.from_unix(total_nanos, :nanosecond)

--- a/lib/msgpax/ext/rsvd_ext.ex
+++ b/lib/msgpax/ext/rsvd_ext.ex
@@ -1,0 +1,101 @@
+defmodule Msgpax.Ext.RsvdUnpacker do
+  use Bitwise
+
+  @behaviour Msgpax.Ext.Unpacker
+
+  defimpl Msgpax.Packer, for: DateTime do
+    @doc """
+    Implemented following this guide
+    https://github.com/msgpack/msgpack/pull/209
+    FixExt4(-1) => seconds |  [1970-01-01 00:00:00 UTC, 2106-02-07 06:28:16 UTC) range
+    FixExt8(-1) => nanoseconds + seconds | [1970-01-01 00:00:00.000000000 UTC, 2514-05-30 01:53:04.000000000 UTC) range
+    Ext8(12,-1) => nanoseconds + seconds | [-584554047284-02-23 16:59:44 UTC, 584554051223-11-09 07:00:16.000000000 UTC) range
+
+    Pseudo code for serialization:
+    struct timespec {
+        long tv_sec;  // seconds
+        long tv_nsec; // nanoseconds
+    } time;
+    if ((time.tv_sec >> 34) == 0) {
+        uint64_t data64 = (time.tv_nsec << 34) | time.tv_sec;
+        if (data & 0xffffffff00000000L == 0) {
+            // timestamp 32
+            uint32_t data32 = data64;
+            serialize(0xd6, -1, data32)
+        }
+        else {
+            // timestamp 64
+            serialize(0xd7, -1, data64)
+        }
+    }
+    else {
+        // timestamp 96
+        serialize(0xc7, 12, -1, time.tv_nsec, time.tv_sec)
+    }
+    """
+    def pack(value) do
+      Msgpax.Ext.new(-1, get_bin(value))
+      |> Msgpax.Packer.pack
+    end
+
+    defp get_bin(time) do
+      seconds = @for.to_unix(time)
+      nanoseconds = @for.to_unix(time, :nanosecond) - seconds * 1000000000
+
+      if (seconds >>> 34) == 0 do
+        data64 = nanoseconds <<< 34 ||| seconds
+        if (data64 &&& 18446744069414584320) == 0 do
+          <<0xd6, -1>> <> <<seconds::32>>
+        else
+          <<0xd7, -1>> <> <<data64::64>>
+        end
+      else
+        <<0xc7, 12, -1>> <> <<nanoseconds::32>> <> <<seconds::64>>
+      end
+    end
+  end
+
+
+  @doc """
+  Pseudo code for deserialization:
+   ExtensionValue value = deserialize_ext_type();
+   struct timespec result;
+   switch(value.length) {
+   case 4:
+       uint32_t data32 = value.payload;
+       result.tv_nsec = 0;
+       result.tv_sec = data32;
+   case 8:
+       uint64_t data64 = value.payload;
+       result.tv_nsec = data64 >> 34;
+       result.tv_sec = data64 & 0x00000003ffffffffL;
+   case 12:
+       uint32_t data32 = value.payload;
+       uint64_t data64 = value.payload + 4;
+       result.tv_nsec = data32;
+       result.tv_sec = data64;
+   default:
+       // error
+   }
+  """
+  def unpack(%Msgpax.Ext{type: -1, data: data}) do
+    <<ext_type, bin::binary>> = data
+    case ext_type do
+      0xd6 ->
+        <<_ext, seconds::32>> = bin
+        DateTime.from_unix(seconds)
+      0xd7 ->
+        <<_ext, data64::64>> = bin
+        nanoseconds = data64 >>> 34;
+        seconds = data64 &&& 17179869183
+        total_nanos = seconds * 1000000000 + nanoseconds
+        DateTime.from_unix(total_nanos, :nanosecond)
+      0xc7 ->
+        <<_ext, _, nanoseconds::32, seconds::64 >> = bin
+        total_nanos = seconds * 1000000000 + nanoseconds
+        DateTime.from_unix(total_nanos, :nanosecond)
+      _->
+        :error
+    end
+  end
+end

--- a/lib/msgpax/ext/rsvd_ext.ex
+++ b/lib/msgpax/ext/rsvd_ext.ex
@@ -1,107 +1,50 @@
-defmodule Msgpax.Ext.RsvdUnpacker do
+defimpl Msgpax.Packer, for: DateTime do
   use Bitwise
 
-  @behaviour Msgpax.Ext.Unpacker
-
-  defimpl Msgpax.Packer, for: DateTime do
-    @doc """
-    Implemented following this guide
-    https://github.com/msgpack/msgpack/pull/209
-    FixExt4(-1) => seconds |  [1970-01-01 00:00:00 UTC, 2106-02-07 06:28:16 UTC) range
-    FixExt8(-1) => nanoseconds + seconds | [1970-01-01 00:00:00.000000000 UTC, 2514-05-30 01:53:04.000000000 UTC) range
-    Ext8(12,-1) => nanoseconds + seconds | [-584554047284-02-23 16:59:44 UTC, 584554051223-11-09 07:00:16.000000000 UTC) range
-
-    Pseudo code for serialization:
-    struct timespec {
-        long tv_sec;  // seconds
-        long tv_nsec; // nanoseconds
-    } time;
-    if ((time.tv_sec >> 34) == 0) {
-        uint64_t data64 = (time.tv_nsec << 34) | time.tv_sec;
-        if (data & 0xffffffff00000000L == 0) {
-            // timestamp 32
-            uint32_t data32 = data64;
-            serialize(0xd6, -1, data32)
-        }
-        else {
-            // timestamp 64
-            serialize(0xd7, -1, data64)
-        }
-    }
-    else {
-        // timestamp 96
-        serialize(0xc7, 12, -1, time.tv_nsec, time.tv_sec)
-    }
-    """
-    def pack(value) do
-      Msgpax.Ext.new(-1, get_bin(value))
-      |> Msgpax.Packer.pack
-    end
-
-    defp get_bin(time) do
-      seconds = @for.to_unix(time)
-      nanoseconds = @for.to_unix(time, :nanosecond) - seconds * 1000000000
-
-      if (seconds >>> 34) == 0 do
-        data64 = nanoseconds <<< 34 ||| seconds
-        if (data64 &&& 18446744069414584320) == 0 do
-          <<seconds::32>>
-        else
-          <<data64::64>>
-        end
-      else
-        <<nanoseconds::32>> <> <<seconds::64>>
-      end
-    end
+  def pack(datetime) do
+    Msgpax.Ext.new(-1, build_data(datetime))
+    |> @protocol.Msgpax.Ext.pack()
   end
 
+  defp build_data(datetime) do
+    total_nanoseconds = @for.to_unix(datetime, :nanosecond)
+    seconds = Integer.floor_div(total_nanoseconds, 1_000_000_000)
+    nanoseconds = Integer.mod(total_nanoseconds, 1_000_000_000)
 
-  @doc """
-  Pseudo code for deserialization:
-   ExtensionValue value = deserialize_ext_type();
-   struct timespec result;
-   switch(value.length) {
-   case 4:
-       uint32_t data32 = value.payload;
-       result.tv_nsec = 0;
-       result.tv_sec = data32;
-   case 8:
-       uint64_t data64 = value.payload;
-       result.tv_nsec = data64 >> 34;
-       result.tv_sec = data64 & 0x00000003ffffffffL;
-   case 12:
-       uint32_t data32 = value.payload;
-       uint64_t data64 = value.payload + 4;
-       result.tv_nsec = data32;
-       result.tv_sec = data64;
-   default:
-       // error
-   }
-  """
+    if (seconds >>> 34) == 0 do
+      content = nanoseconds <<< 34 ||| seconds
+      if (content &&& 0xFFFFFFFF00000000) == 0 do
+        <<content::32>>
+      else
+        <<content::64>>
+      end
+    else
+      <<nanoseconds::32, seconds::64>>
+    end
+  end
+end
+
+defmodule Msgpax.Ext.RsvdUnpacker do
+  @behaviour Msgpax.Ext.Unpacker
+
+  @min_nanoseconds -62_167_219_200_000_000_000
+  @max_nanoseconds 253_402_300_799_999_999_999
+
   def unpack(%Msgpax.Ext{type: -1, data: data}) do
-    case byte_size(data) do
-      4 ->
-        <<seconds::big-integer-size(32)>> = data
+    case data do
+      <<seconds::32>> ->
         DateTime.from_unix(seconds)
-      8 ->
-        <<data64::big-integer-size(64)>> = data
-        nanoseconds = data64 >>> 34;
-        seconds = data64 &&& 17179869183
-        total_nanos = seconds * 1000000000 + nanoseconds
-        DateTime.from_unix(total_nanos, :nanosecond)
-      12 ->
-        <<nanoseconds::big-integer-size(32), seconds::signed-big-integer-size(64)>> = data
-        total_nanos = seconds * 1000000000 + nanoseconds
-        #Erlang only support datetime max to #<DateTime(9999-12-31T23:59:59Z Etc/UTC)>
-        #min to #<DateTime(0000-01-01T00:00:00Z Etc/UTC)>
-        total_nanos =
-        cond do
-          total_nanos < -62167219200000000000 -> -62167219200000000000
-          total_nanos > 253402300799000000999 -> 253402300799000000999
-          true -> total_nanos
+      <<nanoseconds::30, seconds::34>> ->
+        total_nanoseconds = seconds * 1_000_000_000 + nanoseconds
+        DateTime.from_unix(total_nanoseconds, :nanosecond)
+      <<nanoseconds::32, seconds::64-signed>> ->
+        total_nanoseconds = (seconds * 1_000_000_000 + nanoseconds)
+        if total_nanoseconds in @min_nanoseconds..@max_nanoseconds do
+          DateTime.from_unix(total_nanoseconds, :nanosecond)
+        else
+          :error
         end
-        DateTime.from_unix(total_nanos, :nanosecond)
-      _->
+      _ ->
         :error
     end
   end

--- a/lib/msgpax/ext/unpacker.ex
+++ b/lib/msgpax/ext/unpacker.ex
@@ -15,5 +15,5 @@ defmodule Msgpax.Ext.Unpacker do
   It should return `{:ok, value}` to have Msgpax return `value` when unpacking
   the given extension, or `:error` if there's an error while unpacking.
   """
-  @callback unpack(ext :: Msgpax.Ext.t) :: {:ok, any} | :error
+  @callback unpack(ext :: Msgpax.Ext.t | Msgpax.ReservedExt.t) :: {:ok, any} | :error
 end

--- a/lib/msgpax/packer.ex
+++ b/lib/msgpax/packer.ex
@@ -227,8 +227,8 @@ defimpl Msgpax.Packer, for: Msgpax.Bin do
   end
 end
 
-defimpl Msgpax.Packer, for: Msgpax.Ext do
-  def pack(%{type: type, data: data}) do
+defimpl Msgpax.Packer, for: [Msgpax.Ext, Msgpax.ReservedExt] do
+  def pack(%_{type: type, data: data}) do
     [format(data), <<type>> | data]
   end
 

--- a/lib/msgpax/packer.ex
+++ b/lib/msgpax/packer.ex
@@ -229,7 +229,7 @@ end
 
 defimpl Msgpax.Packer, for: Msgpax.Ext do
   def pack(%{type: type, data: data}) do
-    [format(data), type | data]
+    [format(data), <<type>> | data]
   end
 
   defp format(data) do

--- a/lib/msgpax/unpacker.ex
+++ b/lib/msgpax/unpacker.ex
@@ -7,7 +7,6 @@ defmodule Msgpax.UnpackError do
     reason: {:excess_bytes, binary} |
             {:invalid_format, integer} |
             :incomplete |
-            {:not_supported_ext, integer} |
             {:ext_unpack_failure, module, Msgpax.Ext.t},
   }
 
@@ -21,8 +20,6 @@ defmodule Msgpax.UnpackError do
         "invalid format, first byte: #{byte}"
       :incomplete ->
         "given binary is incomplete"
-      {:not_supported_ext, type} ->
-        "extension type is not supported: #{type}"
       {:ext_unpack_failure, module, struct} ->
         "module #{inspect(module)} could not unpack extension: #{inspect(struct)}"
     end
@@ -173,18 +170,15 @@ defmodule Msgpax.Unpacker do
   end
 
   defp unpack_ext(type, content, options) do
-    cond do
-      type in 0..127 ->
-        type
-        |> Msgpax.Ext.new(content)
-        |> unpack_ext(options)
-      type in 128..255 ->
-        type = type - 256
-        type
-        |> Msgpax.Ext.new(content)
-        |> unpack_ext(%{ext: Msgpax.Ext.RsvdUnpacker})
-      true ->
-      throw({:not_supported_ext, type})
+    if type < 128 do
+      type
+      |> Msgpax.Ext.new(content)
+      |> unpack_ext(options)
+    else
+      type
+      |> Kernel.-(256)
+      |> Msgpax.ReservedExt.new(content)
+      |> unpack_ext(%{ext: Msgpax.ReservedExt})
     end
   end
 

--- a/lib/msgpax/unpacker.ex
+++ b/lib/msgpax/unpacker.ex
@@ -173,11 +173,17 @@ defmodule Msgpax.Unpacker do
   end
 
   defp unpack_ext(type, content, options) do
-    if type in 0..127 do
-      type
-      |> Msgpax.Ext.new(content)
-      |> unpack_ext(options)
-    else
+    cond do
+      type in 0..127 ->
+        type
+        |> Msgpax.Ext.new(content)
+        |> unpack_ext(options)
+      type in 128..255 ->
+        type = type - 256
+        type
+        |> Msgpax.Ext.new(content)
+        |> unpack_ext(%{ext: Msgpax.Ext.RsvdUnpacker})
+      true ->
       throw({:not_supported_ext, type})
     end
   end

--- a/test/msgpax/ext_test.exs
+++ b/test/msgpax/ext_test.exs
@@ -90,8 +90,8 @@ defmodule Msgpax.ExtTest do
     assert reason == {:ext_unpack_failure, Broken, Msgpax.Ext.new(42, "A")}
   end
 
-  test "bad ext type" do
-    assert {:error, %UnpackError{reason: reason}} = Msgpax.unpack(<<0xD4, -1, 65>>)
-    assert reason == {:not_supported_ext, 255}
+  test "not supported reserved ext type" do
+    assert {:error, %UnpackError{reason: reason}} = Msgpax.unpack(<<0xD4, -5, 65>>)
+    assert reason == {:not_supported_reserved_ext, -5}
   end
 end

--- a/test/msgpax/ext_test.exs
+++ b/test/msgpax/ext_test.exs
@@ -91,7 +91,7 @@ defmodule Msgpax.ExtTest do
   end
 
   test "not supported reserved ext type" do
-    assert {:error, %UnpackError{reason: reason}} = Msgpax.unpack(<<0xD4, -5, 65>>)
-    assert reason == {:not_supported_reserved_ext, -5}
+    assert {:ok, result} = Msgpax.unpack(<<0xD4, -5, 65>>)
+    assert result == %Msgpax.ReservedExt{data: "A", type: -5}
   end
 end

--- a/test/msgpax_test.exs
+++ b/test/msgpax_test.exs
@@ -219,22 +219,30 @@ defmodule MsgpaxTest do
     assert Msgpax.pack!(%UserDerivingStructField{name: "Juri"}) == expected
   end
 
-  test "timestamp" do
-    {_, date, _} =DateTime.from_iso8601("0001-01-01T00:00:00Z")
-    bin = Msgpax.pack!(date, iodata: false)
-    assert DateTime.compare(date, Msgpax.unpack!(bin)) == :eq
+  test "timestamp ext" do
+    string =
+      if Version.match?(System.version(), "<= 1.5.1") do
+        "0001-01-01T00:00:00.000000Z"
+      else
+        "0001-01-01T00:00:00.000001Z"
+      end
+    {:ok, datetime, 0} = DateTime.from_iso8601(string)
+    assert_format datetime, []
 
-    {_, date, _} =DateTime.from_iso8601("1970-01-01T00:00:00Z")
-    bin = Msgpax.pack!(date, iodata: false)
-    assert DateTime.compare(date, Msgpax.unpack!(bin)) == :eq
-    
-    date = DateTime.utc_now
-    bin = Msgpax.pack!(date, iodata: false)
-    assert DateTime.compare(date, Msgpax.unpack!(bin)) == :eq
-    
-    {_, date, _} =DateTime.from_iso8601("9999-12-31T23:59:59Z")
-    bin = Msgpax.pack!(date, iodata: false)
-    assert DateTime.compare(date, Msgpax.unpack!(bin)) == :eq
+    {:ok, datetime, 0} = DateTime.from_iso8601("1970-01-01T00:00:00Z")
+    assert_format datetime, []
+
+    datetime = DateTime.utc_now()
+    assert_format datetime, []
+
+    string =
+      if Version.match?(System.version(), "<= 1.5.2") do
+        "9999-12-31T23:59:59.0000000Z"
+      else
+        "9999-12-31T23:59:59.9999999Z"
+      end
+    {:ok, datetime, 0} = DateTime.from_iso8601(string)
+    assert_format datetime, []
   end
 
   defp build_string(length) do

--- a/test/msgpax_test.exs
+++ b/test/msgpax_test.exs
@@ -219,6 +219,24 @@ defmodule MsgpaxTest do
     assert Msgpax.pack!(%UserDerivingStructField{name: "Juri"}) == expected
   end
 
+  test "timestamp" do
+    {_, date, _} =DateTime.from_iso8601("0001-01-01T00:00:00Z")
+    bin = Msgpax.pack!(date, iodata: false)
+    assert DateTime.compare(date, Msgpax.unpack!(bin)) == :eq
+
+    {_, date, _} =DateTime.from_iso8601("1970-01-01T00:00:00Z")
+    bin = Msgpax.pack!(date, iodata: false)
+    assert DateTime.compare(date, Msgpax.unpack!(bin)) == :eq
+    
+    date = DateTime.utc_now
+    bin = Msgpax.pack!(date, iodata: false)
+    assert DateTime.compare(date, Msgpax.unpack!(bin)) == :eq
+    
+    {_, date, _} =DateTime.from_iso8601("9999-12-31T23:59:59Z")
+    bin = Msgpax.pack!(date, iodata: false)
+    assert DateTime.compare(date, Msgpax.unpack!(bin)) == :eq
+  end
+
   defp build_string(length) do
     String.duplicate(".", length)
   end


### PR DESCRIPTION
Implemented following:
https://github.com/msgpack/msgpack/pull/209
https://github.com/msgpack/msgpack/pull/209/files#r48227803

Result:

```
iex(1)> data = Msgpax.pack!(DateTime.utc_now) |> IO.iodata_to_binary
<<215, 255, 48, 171, 89, 192, 89, 24, 114, 72>>
iex(2)> Msgpax.unpack!(data)                                        
#<DateTime(2017-05-14T15:05:44.204134Z Etc/UTC)>
```