### PR TITLE
Fix plug.parsers behaviour warning

### DIFF
--- a/lib/msgpax/plug_parser.ex
+++ b/lib/msgpax/plug_parser.ex
@@ -35,6 +35,10 @@ if Code.ensure_compiled?(Plug) do
       {:next, conn}
     end
 
+    def init(opts) do
+      opts
+    end
+
     defp unpack_body(body) do
       case Msgpax.unpack!(body) do
         data when is_map(data) -> data

--- a/lib/msgpax/plug_parser.ex
+++ b/lib/msgpax/plug_parser.ex
@@ -35,9 +35,7 @@ if Code.ensure_compiled?(Plug) do
       {:next, conn}
     end
 
-    def init(opts) do
-      opts
-    end
+    def init(opts), do: opts
 
     defp unpack_body(body) do
       case Msgpax.unpack!(body) do


### PR DESCRIPTION
Fix below warning

```
==> msgpax
Compiling 7 files (.ex)
warning: function init/1 required by behaviour Plug.Parsers is not implemented (in module Msgpax.PlugParser)
  lib/msgpax/plug_parser.ex:2

Generated msgpax app
```