### PR TITLE
Remove warning in elixir 1.8: due to for :into with non empty list

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.8-otp-21
+erlang 21.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-elixir 1.8-otp-21
-erlang 21.2

--- a/lib/msgpax/packer.ex
+++ b/lib/msgpax/packer.ex
@@ -145,9 +145,10 @@ defimpl Msgpax.Packer, for: Map do
   end
 
   def pack(map) do
-    for {key, value} <- map, into: [format(map)] do
-      [@protocol.pack(key) | @protocol.pack(value)]
-    end
+    [format(map)] ++
+      for {key, value} <- map do
+        [@protocol.pack(key) | @protocol.pack(value)]
+      end
   end
 
   defp format(map) do
@@ -164,9 +165,10 @@ end
 
 defimpl Msgpax.Packer, for: List do
   def pack(list) do
-    for item <- list, into: [format(list)] do
-      @protocol.pack(item)
-    end
+    [format(list)] ++
+      for item <- list do
+        @protocol.pack(item)
+      end
   end
 
   defp format(list) do


### PR DESCRIPTION
It fixes the following warning
warning: the Collectable protocol is deprecated for non-empty lists. The
behaviour of things like Enum.into/2 or "for" comprehensions with an
:into option is incorrect when collecting into non-empty lists. If
you're collecting into a non-empty keyword list, consider using
Keyword.merge/2 instead. If you're collecting into a non-empty list,
consider concatenating the two lists with the ++ operator.
  (elixir) lib/collectable.ex:83: Collectable.List.into/1
    (stdlib) erl_eval.erl:680: :erl_eval.do_apply/6
      (stdlib) erl_eval.erl:449: :erl_eval.expr/5
        (stdlib) erl_eval.erl:126: :erl_eval.exprs/5
          (elixir) src/elixir.erl:258: :elixir.eval_forms/4