### PR TITLE
Exclude default packers

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,12 @@
+use Mix.Config
+
+config :msgpax, exclude_packers: []
+
+case System.get_env("TEST_EXCLUDE", "") do
+  "" ->
+    nil
+  other ->
+    config :msgpax, exclude_packers: String.split(other, ",") |> Enum.map(& &1 |> String.to_atom() )
+end
+
+#  import_config "#{Mix.env()}.exs"

--- a/lib/msgpax.ex
+++ b/lib/msgpax.ex
@@ -26,6 +26,15 @@ defmodule Msgpax do
   `#Msgpax.Ext<4, "02:12">`         | extension     | `#Msgpax.Ext<4, "02:12">`
   `#DateTime<2017-12-06 00:00:00Z>` | extension     | `#DateTime<2017-12-06 00:00:00Z>`
 
+  ## Excluding Default Packers
+
+  Default packers can be excluded by passing a config option:
+    `config: :msgpack, exclude_packers: [:atom, :float]`
+
+  The packers that can be exlucded are: :atom, :bitstring, :map, :list, :float, :integer, and :bin
+
+  This can be used to override default behaviors, like serializing to float32s. Use this sparingly as it's global and can break things.
+
   """
 
   alias __MODULE__.Packer

--- a/lib/msgpax/packer_macros.ex
+++ b/lib/msgpax/packer_macros.ex
@@ -1,0 +1,8 @@
+
+defmodule MsgPax.PackerMacros do
+  defmacro excluded?(packer_type, do: block) do
+    unless packer_type in Application.get_env(:msgpax, :exclude_packers, []) do
+      block # AST as by quote do: unquote(block)
+    end
+  end
+end

--- a/lib/msgpax/plug_parser.ex
+++ b/lib/msgpax/plug_parser.ex
@@ -81,7 +81,7 @@ if Code.ensure_compiled(Plug) == {:module, Plug} do
          when is_atom(module) and is_atom(function) and is_list(extra_args) do
       arity = length(extra_args) + 1
 
-      unless Code.ensure_compiled?(module) and function_exported?(module, function, arity) do
+      unless Code.ensure_compiled(module) == {:module, module} and function_exported?(module, function, arity) do
         raise ArgumentError,
               "invalid :unpacker option. Undefined function " <>
                 Exception.format_mfa(module, function, arity)
@@ -89,7 +89,7 @@ if Code.ensure_compiled(Plug) == {:module, Plug} do
     end
 
     defp validate_unpacker!(unpacker) when is_atom(unpacker) do
-      unless Code.ensure_compiled?(unpacker) do
+      unless Code.ensure_compiled(unpacker) == {:module, unpacker} do
         raise ArgumentError,
               "invalid :unpacker option. The module #{inspect(unpacker)} is not " <>
                 "loaded and could not be found"

--- a/lib/msgpax/plug_parser.ex
+++ b/lib/msgpax/plug_parser.ex
@@ -1,4 +1,4 @@
-if Code.ensure_compiled?(Plug) do
+if Code.ensure_compiled(Plug) == {:module, Plug} do
   defmodule Msgpax.PlugParser do
     @moduledoc """
     A `Plug.Parsers` plug for parsing a MessagePack-encoded body.


### PR DESCRIPTION
Adds the option to exclude a set of default packers. The use case for this is rare, but can allow people to customize behavior as wanted in a global fashion. In this case, I need to be able to set the float serialization type to float32. I started with a branch allowing just that, but this seemed to be better and could let someone override other default packers should they want to (say serialize maps to ordered list pairs or something odd). 

The config options is: ` config :msgpax, exclude_packers: [:atom, :map, ...] `. 